### PR TITLE
Added dev-mode.yaml

### DIFF
--- a/conf/dev-mode.yaml
+++ b/conf/dev-mode.yaml
@@ -1,0 +1,1 @@
+gateway: true


### PR DESCRIPTION
Added dev-mode.yaml with the content:

`gateway: true`

I added the file manually and was able to run the quick start correctly. It worked perfectly fine.

Hence, making a PR with this file to fix the issue stated https://github.com/hasura/hello-nodejs-express/issues/5 here.